### PR TITLE
Add language selection to Tippy (closes #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.1.7",
     "color-scheme": "^1.0.1",
+    "dompurify": "^2.2.7",
     "firebase": "^8.2.3",
     "i18next": "^19.9.2",
     "i18next-browser-languagedetector": "^6.0.1",
@@ -55,6 +56,7 @@
     ]
   },
   "devDependencies": {
+    "@types/dompurify": "^2.2.1",
     "@types/rc-slider": "^8.6.6",
     "@types/react-router-dom": "^5.1.7"
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.1.7",
     "color-scheme": "^1.0.1",
-    "dompurify": "^2.2.7",
     "firebase": "^8.2.3",
     "i18next": "^19.9.2",
     "i18next-browser-languagedetector": "^6.0.1",
@@ -56,7 +55,6 @@
     ]
   },
   "devDependencies": {
-    "@types/dompurify": "^2.2.1",
     "@types/rc-slider": "^8.6.6",
     "@types/react-router-dom": "^5.1.7"
   }

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -15,10 +15,12 @@
     "roomidheader": {
         "roomid": "Raum ID:",
         "reset_room": "Setze Raum zurück",
-        "switch_language_header": "Sprache ändern",
-        "switch_language_en": "English",
-        "switch_language_de": "Deutsch"
-    },
+        "switch_language_header": "Spracheinstellung",
+        "language_en_flag": "&#127468;&#127463;",
+        "language_en": "English",
+        "language_de_flag": "&#127465;&#127466;",
+        "language_de": "Deutsch"
+        },
     "spectrum": {
         "guessing": "Raten...",
         "target": "Ziel"

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -14,7 +14,10 @@
     },
     "roomidheader": {
         "roomid": "Raum ID:",
-        "reset_room": "Setze Raum zurück"
+        "reset_room": "Setze Raum zurück",
+        "switch_language_header": "Sprache ändern",
+        "switch_language_en": "English",
+        "switch_language_de": "Deutsch"
     },
     "spectrum": {
         "guessing": "Raten...",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -16,9 +16,7 @@
         "roomid": "Raum ID:",
         "reset_room": "Setze Raum zurück",
         "switch_language_header": "Spracheinstellung",
-        "language_en_flag": "&#127468;&#127463;",
         "language_en": "English",
-        "language_de_flag": "&#127465;&#127466;",
         "language_de": "Deutsch"
         },
     "spectrum": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -14,7 +14,10 @@
   },
   "roomidheader": {
     "roomid": "Room ID:",
-    "reset_room": "Reset Room"
+    "reset_room": "Reset Room",
+    "switch_language_header": "Switch language",
+    "switch_language_en": "English",
+    "switch_language_de": "Deutsch"
   },
   "spectrum": {
     "guessing": "Guessing...",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -15,9 +15,11 @@
   "roomidheader": {
     "roomid": "Room ID:",
     "reset_room": "Reset Room",
-    "switch_language_header": "Switch language",
-    "switch_language_en": "English",
-    "switch_language_de": "Deutsch"
+    "switch_language_header": "Language setting",
+    "language_en_flag": "&#127468;&#127463;<script>alert('hello');</script>",
+    "language_en": "English",
+    "language_de_flag": "&#127465;&#127466;",
+    "language_de": "Deutsch"
   },
   "spectrum": {
     "guessing": "Guessing...",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -16,9 +16,7 @@
     "roomid": "Room ID:",
     "reset_room": "Reset Room",
     "switch_language_header": "Language setting",
-    "language_en_flag": "&#127468;&#127463;<script>alert('hello');</script>",
     "language_en": "English",
-    "language_de_flag": "&#127465;&#127466;",
     "language_de": "Deutsch"
   },
   "spectrum": {

--- a/src/components/common/RoomIdHeader.tsx
+++ b/src/components/common/RoomIdHeader.tsx
@@ -10,6 +10,7 @@ import { GameModelContext } from "../../state/GameModelContext";
 import { InitialGameState } from "../../state/GameState";
 
 import { useTranslation } from "react-i18next";
+import DOMPurify from "dompurify";
 
 export function RoomIdHeader() {
   const { t } = useTranslation();
@@ -65,15 +66,14 @@ function RoomMenu() {
         style={{ cursor: "pointer" }}
         onClick={() => changeLanguage("en")}
       >
-        &#127468;&#127463;{" "}{t("roomidheader.switch_language_en")}
+        <div dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(t('roomidheader.language_en_flag') + "&nbsp;" + t("roomidheader.language_en"))}} />
       </div>
       <div
         tabIndex={2}
         style={{ cursor: "pointer" }}
         onClick={() => changeLanguage("de")}
       >
-        &#127465;&#127466;{" "}{t("roomidheader.switch_language_de")}
-      </div>
+        <div dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(t('roomidheader.language_de_flag') + "&nbsp;" + t("roomidheader.language_de"))}} />      </div>
     </div>
   );
 }

--- a/src/components/common/RoomIdHeader.tsx
+++ b/src/components/common/RoomIdHeader.tsx
@@ -10,7 +10,6 @@ import { GameModelContext } from "../../state/GameModelContext";
 import { InitialGameState } from "../../state/GameState";
 
 import { useTranslation } from "react-i18next";
-import DOMPurify from "dompurify";
 
 export function RoomIdHeader() {
   const { t } = useTranslation();
@@ -66,14 +65,15 @@ function RoomMenu() {
         style={{ cursor: "pointer" }}
         onClick={() => changeLanguage("en")}
       >
-        <div dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(t('roomidheader.language_en_flag') + "&nbsp;" + t("roomidheader.language_en"))}} />
+        &#127468;&#127463;{" "}{t("roomidheader.language_en")}
       </div>
       <div
         tabIndex={2}
         style={{ cursor: "pointer" }}
         onClick={() => changeLanguage("de")}
       >
-        <div dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(t('roomidheader.language_de_flag') + "&nbsp;" + t("roomidheader.language_de"))}} />      </div>
+        &#127465;&#127466;{" "}{t("roomidheader.language_de")}
+      </div>
     </div>
   );
 }

--- a/src/components/common/RoomIdHeader.tsx
+++ b/src/components/common/RoomIdHeader.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import { CenteredRow } from "./LayoutElements";
-import { faEllipsisV } from "@fortawesome/free-solid-svg-icons";
+import { faCogs } from "@fortawesome/free-solid-svg-icons";
+import { faUndo } from "@fortawesome/free-solid-svg-icons";
 import Tippy from "@tippyjs/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useContext } from "react";
@@ -27,7 +28,7 @@ export function RoomIdHeader() {
       </div>
       <Tippy content={<RoomMenu />} interactive placement="bottom-end">
         <div tabIndex={0} style={{ padding: 8 }}>
-          <FontAwesomeIcon icon={faEllipsisV} />
+          <FontAwesomeIcon icon={faCogs} />
         </div>
       </Tippy>
     </CenteredRow>
@@ -35,16 +36,44 @@ export function RoomIdHeader() {
 }
 
 function RoomMenu() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+
+  const changeLanguage = (language: string | undefined) => {
+    i18n.changeLanguage(language);
+  };
+
   const { setGameState } = useContext(GameModelContext);
 
+  // Information about HTML flag symbols: https://emojiguide.org/flags
   return (
-    <div
-      tabIndex={0}
-      style={{ cursor: "pointer" }}
-      onClick={() => setGameState(InitialGameState())}
-    >
-      {t("roomidheader.reset_room")}
+    <div>
+      <div
+        tabIndex={0}
+        style={{ cursor: "pointer" }}
+        onClick={() => setGameState(InitialGameState())}
+      >
+        <FontAwesomeIcon icon={faUndo} />{" "}{t("roomidheader.reset_room")}
+      </div>
+
+      <div
+        tabIndex={1}
+      >
+        {t("roomidheader.switch_language_header")}:
+      </div>
+      <div
+        tabIndex={2}
+        style={{ cursor: "pointer" }}
+        onClick={() => changeLanguage("en")}
+      >
+        &#127468;&#127463;{" "}{t("roomidheader.switch_language_en")}
+      </div>
+      <div
+        tabIndex={2}
+        style={{ cursor: "pointer" }}
+        onClick={() => changeLanguage("de")}
+      >
+        &#127465;&#127466;{" "}{t("roomidheader.switch_language_de")}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
To enable language selection in every screen, the Tippy menu has been adapted. 

<img width="233" alt="image" src="https://user-images.githubusercontent.com/25303664/111066432-4b302b00-84bf-11eb-8bdb-184df6ce42b8.png">

<img width="227" alt="image" src="https://user-images.githubusercontent.com/25303664/111066460-7dda2380-84bf-11eb-8d16-46df1bb333a8.png">

It now has a more speaking icon and more menu items for language selection. The Reset Room entry has been provided with an "Undo" icon for better visualisation. Furthermore, the language selections have been provided with HTML codes of the corresponding country flags. Please excuse that I only used the GB flag as an example and not the US flag in addition ;)

Personally, I would make the tippy a little more "lighter" (light theme, more distance), but I haven't actually figured out how to specify the tippy options (for example, "theme" or "distance"). Selected entries still show a selection frame that is slightly larger than the row.

Please see the PR as a suggestion to allow language selection at any time.

another hint: should the country flags not make it across the PR, I would leave the language names in the native language in any translation so that someone can read and recognise their own language (for example, "Deutsch" instead of "german"). 

 This PR closes issue #8.