### PR TITLE
Add contrasting text for spectrum cards (closes #11)

### DIFF
--- a/src/components/common/GetContrastingText.ts
+++ b/src/components/common/GetContrastingText.ts
@@ -1,0 +1,39 @@
+interface RGB {
+  b: number;
+  g: number;
+  r: number;
+}
+
+function hex2Rgb(hex: string): RGB | undefined {
+  if (!hex || hex === undefined || hex === '') {
+      return undefined;
+  }
+
+  const result: RegExpExecArray | null =
+        /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+
+  return result ? {
+      r: parseInt(result[1], 16),
+      g: parseInt(result[2], 16),
+      b: parseInt(result[3], 16)
+  } : undefined;
+}
+
+function rgb2YIQ({ r, g, b }: RGB): number {
+  return ((r * 299) + (g * 587) + (b * 114)) / 1000;
+}
+
+export function GetContrastingText(colorHex: string | undefined,
+                       threshold: number = 128): string {
+  if (colorHex === undefined) {
+      return '#000';
+  }
+
+  const rgb: RGB | undefined = hex2Rgb(colorHex);
+
+  if (rgb === undefined) {
+      return '#000';
+  }
+
+  return rgb2YIQ(rgb) >= threshold ? '#000' : '#fff';
+}

--- a/src/components/common/Spectrum.tsx
+++ b/src/components/common/Spectrum.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Slider from "rc-slider";
 import { CenteredColumn, CenteredRow } from "./LayoutElements";
 import { GetContrastingColors } from "./GetContrastingColors";
+import { GetContrastingText } from "./GetContrastingText";
 
 import { useTranslation } from "react-i18next";
 
@@ -21,6 +22,8 @@ export function Spectrum(props: {
     padding: 8,
     fontWeight: "bold",
   };
+  const primaryText = GetContrastingText(primary);
+  const secondaryText = GetContrastingText(secondary);
 
   let handleStyle: React.CSSProperties = {
     height: 18,
@@ -68,10 +71,10 @@ export function Spectrum(props: {
     <div style={{ padding: 8 }}>
       <CenteredColumn style={{ alignItems: "stretch" }}>
         <CenteredRow style={{ justifyContent: "space-between" }}>
-          <div style={{ ...cardBackStyle, backgroundColor: primary }}>
+          <div style={{ ...cardBackStyle, backgroundColor: primary, color: primaryText }}>
             {props.spectrumCard[0]}
           </div>
-          <div style={{ ...cardBackStyle, backgroundColor: secondary }}>
+          <div style={{ ...cardBackStyle, backgroundColor: secondary, color: secondaryText }}>
             {props.spectrumCard[1]}
           </div>
         </CenteredRow>


### PR DESCRIPTION
The following PR adds a function to determine a text colour for the spectrum maps with sufficient contrast. This only differentiates between light (#FFF) and dark (#000) text colour based on the background of the spectrum maps. 

This PR closes issue #11.