### PR TITLE
Fix t-function call (closes issue #16)

### DIFF
--- a/src/components/gameplay/ViewScore.tsx
+++ b/src/components/gameplay/ViewScore.tsx
@@ -125,7 +125,7 @@ function NextTurnOrEndGame() {
         <div>
           {t("viewscore.final_score_team")}:{" "}
           <strong>
-            {gameState.coopScore} {test("viewscore.points")}
+            {gameState.coopScore} {t("viewscore.points")}
           </strong>
         </div>
         {resetButton}


### PR DESCRIPTION
Function call `t()` was misspelled to `test()` by VS code autocomplete  :( 

Closes issue #16 