### PR TITLE
Add german translation for new "change_name" (closes #13)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -15,6 +15,7 @@
     "roomidheader": {
         "roomid": "Raum ID:",
         "reset_room": "Setze Raum zurück",
+        "change_name": "Ändere Spielername",
         "switch_language_header": "Spracheinstellung",
         "language_en": "English",
         "language_de": "Deutsch"


### PR DESCRIPTION
The new roomidheader.change_name is translated to german by this PR. Other languages may also need to be translated. Due to the previous implementation, Issue #13 can be closed with Merge this PR at the latest.